### PR TITLE
Updated transform_receive function

### DIFF
--- a/src/diff.erl
+++ b/src/diff.erl
@@ -74,7 +74,8 @@ parse_diff(DiffStr) ->
 -spec extract_file(string()) -> filename().
 extract_file(DiffLine) ->
     Options = [global, {capture, [1,2], list}],
-    {match, [[OrigFile, RefacFile]]} = re:run(DiffLine, ".*?(/.*?\.erl).*?(/.*?\.erl)", Options),
+    %% matching explicitly for the .erl file extension at the end
+    {match, [[OrigFile, RefacFile]]} = re:run(DiffLine, ".*?(/[^[:space:]]*\.erl).*?(/[^[:space:]]*\.erl)", Options),
     equivchecker_utils:common_filename_postfix(OrigFile, RefacFile).
 
 % Checks if the given file in the diff output is erlang source code


### PR DESCRIPTION
- Fixed the regular expression responsible for matching the .erl file extension because it also matched with folders that had "erl" in them before.

- The new transform_recieve function extracts patterns from the receive clause, generates random test data based on those patterns using PropEr, and sends the generated data back to the process.

- The function constructs an AST block that combines the random data generation, message sending, and the original receive expression using erl_syntax.